### PR TITLE
Revert to cgroup v1 freezer in CachedAppOptimizer [1/2]

### DIFF
--- a/services/core/java/com/android/server/am/CachedAppOptimizer.java
+++ b/services/core/java/com/android/server/am/CachedAppOptimizer.java
@@ -737,6 +737,18 @@ public final class CachedAppOptimizer {
     }
 
     /**
+     * Enable or disable the freezer. When enable == false all frozen processes are unfrozen,
+     * but aren't removed from the freezer. While in this state, processes can be added or removed
+     * by using Process.setProcessFrozen(), but they wouldn't be actually frozen until the freezer
+     * is enabled. If enable == true all processes in the freezer are frozen.
+     *
+     * @param enable Specify whether to enable (true) or disable (false) the freezer.
+     *
+     * @hide
+     */
+    private static native void enableFreezerInternal(boolean enable);
+
+    /**
      * Informs binder that a process is about to be frozen. If freezer is enabled on a process via
      * this method, this method will synchronously dispatch all pending transactions to the
      * specified pid. This method will not add significant latencies when unfreezing.
@@ -782,6 +794,10 @@ public final class CachedAppOptimizer {
                 // Also check freezer binder ioctl
                 getBinderFreezeInfo(Process.myPid());
                 supported = true;
+                // This is a workaround after reverting the cgroup v2 uid/pid hierarchy due to
+                // http://b/179006802.
+                // TODO: remove once the uid/pid hierarchy is restored
+                enableFreezerInternal(true);
             } else {
                 Slog.e(TAG_AM, "unexpected value in cgroup.freeze");
             }

--- a/services/core/java/com/android/server/am/CachedAppOptimizer.java
+++ b/services/core/java/com/android/server/am/CachedAppOptimizer.java
@@ -774,12 +774,6 @@ public final class CachedAppOptimizer {
     private static native int getBinderFreezeInfo(int pid);
 
     /**
-     * Returns the path to be checked to verify whether the freezer is supported by this system.
-     * @return absolute path to the file
-     */
-    private static native String getFreezerCheckPath();
-
-    /**
      * Determines whether the freezer is supported by this system
      */
     public static boolean isFreezerSupported() {
@@ -787,7 +781,7 @@ public final class CachedAppOptimizer {
         FileReader fr = null;
 
         try {
-            fr = new FileReader(getFreezerCheckPath());
+            fr = new FileReader("/sys/fs/cgroup/uid_0/cgroup.freeze");
             char state = (char) fr.read();
 
             if (state == '1' || state == '0') {

--- a/services/core/java/com/android/server/am/CachedAppOptimizer.java
+++ b/services/core/java/com/android/server/am/CachedAppOptimizer.java
@@ -781,17 +781,13 @@ public final class CachedAppOptimizer {
         FileReader fr = null;
 
         try {
-            fr = new FileReader("/sys/fs/cgroup/uid_0/cgroup.freeze");
-            char state = (char) fr.read();
+            fr = new FileReader("/dev/freezer/frozen/freezer.killable");
+            int i = fr.read();
 
-            if (state == '1' || state == '0') {
+            if ((char) i == '1') {
                 // Also check freezer binder ioctl
                 getBinderFreezeInfo(Process.myPid());
                 supported = true;
-                // This is a workaround after reverting the cgroup v2 uid/pid hierarchy due to
-                // http://b/179006802.
-                // TODO: remove once the uid/pid hierarchy is restored
-                enableFreezerInternal(true);
             } else {
                 Slog.e(TAG_AM, "unexpected value in cgroup.freeze");
             }

--- a/services/core/jni/com_android_server_am_CachedAppOptimizer.cpp
+++ b/services/core/jni/com_android_server_am_CachedAppOptimizer.cpp
@@ -472,6 +472,21 @@ static void com_android_server_am_CachedAppOptimizer_compactProcess(JNIEnv*, job
     compactProcessOrFallback(pid, compactionFlags);
 }
 
+static void com_android_server_am_CachedAppOptimizer_enableFreezerInternal(
+        JNIEnv *env, jobject clazz, jboolean enable) {
+    bool success = true;
+
+    if (enable) {
+        success = SetTaskProfiles(0, {"FreezerEnabled"}, true);
+    } else {
+        success = SetTaskProfiles(0, {"FreezerDisabled"}, true);
+    }
+
+    if (!success) {
+        jniThrowException(env, "java/lang/RuntimeException", "Unknown error");
+    }
+}
+
 static jint com_android_server_am_CachedAppOptimizer_freezeBinder(
         JNIEnv *env, jobject clazz, jint pid, jboolean freeze) {
 
@@ -518,6 +533,8 @@ static const JNINativeMethod sMethods[] = {
          (void*)com_android_server_am_CachedAppOptimizer_getFreeSwapPercent},
         {"compactSystem", "()V", (void*)com_android_server_am_CachedAppOptimizer_compactSystem},
         {"compactProcess", "(II)V", (void*)com_android_server_am_CachedAppOptimizer_compactProcess},
+        {"enableFreezerInternal", "(Z)V",
+         (void*)com_android_server_am_CachedAppOptimizer_enableFreezerInternal},
         {"freezeBinder", "(IZ)I", (void*)com_android_server_am_CachedAppOptimizer_freezeBinder},
         {"getBinderFreezeInfo", "(I)I",
          (void*)com_android_server_am_CachedAppOptimizer_getBinderFreezeInfo},

--- a/services/core/jni/com_android_server_am_CachedAppOptimizer.cpp
+++ b/services/core/jni/com_android_server_am_CachedAppOptimizer.cpp
@@ -520,11 +520,6 @@ static jint com_android_server_am_CachedAppOptimizer_getBinderFreezeInfo(JNIEnv 
     return retVal;
 }
 
-static jstring com_android_server_am_CachedAppOptimizer_getFreezerCheckPath(JNIEnv* env,
-                                                                            jobject clazz) {
-    return env->NewStringUTF(CGROUP_FREEZE_PATH);
-}
-
 static const JNINativeMethod sMethods[] = {
         /* name, signature, funcPtr */
         {"cancelCompaction", "()V",
@@ -537,9 +532,7 @@ static const JNINativeMethod sMethods[] = {
          (void*)com_android_server_am_CachedAppOptimizer_enableFreezerInternal},
         {"freezeBinder", "(IZ)I", (void*)com_android_server_am_CachedAppOptimizer_freezeBinder},
         {"getBinderFreezeInfo", "(I)I",
-         (void*)com_android_server_am_CachedAppOptimizer_getBinderFreezeInfo},
-        {"getFreezerCheckPath", "()Ljava/lang/String;",
-         (void*)com_android_server_am_CachedAppOptimizer_getFreezerCheckPath}};
+         (void*)com_android_server_am_CachedAppOptimizer_getBinderFreezeInfo}};
 
 int register_android_server_am_CachedAppOptimizer(JNIEnv* env)
 {

--- a/services/core/jni/com_android_server_am_CachedAppOptimizer.cpp
+++ b/services/core/jni/com_android_server_am_CachedAppOptimizer.cpp
@@ -507,13 +507,7 @@ static jint com_android_server_am_CachedAppOptimizer_getBinderFreezeInfo(JNIEnv 
 
 static jstring com_android_server_am_CachedAppOptimizer_getFreezerCheckPath(JNIEnv* env,
                                                                             jobject clazz) {
-    std::string path;
-
-    if (!getAttributePathForTask("FreezerState", getpid(), &path)) {
-        path = "";
-    }
-
-    return env->NewStringUTF(path.c_str());
+    return env->NewStringUTF(CGROUP_FREEZE_PATH);
 }
 
 static const JNINativeMethod sMethods[] = {


### PR DESCRIPTION
This patchset allows to freeze background/cached apps to prevent unwanted activity and save some resources on devices without cgroup v2 freezer controller.

I am use these patches for a while in my builds for a6010 (kernel 3.10).

There is a requirements to get this working:

**Kernel needs a backports**
Freezer:
https://github.com/acroreiser/android_kernel_lenovo_a6010/commit/ce53aa1f64c67f98da96a043728b5be6c5b6f6ae

Binder:
https://github.com/acroreiser/android_kernel_lenovo_a6010/commit/1ae418f9e0578351387608cddc4b3c925fa5e173
https://github.com/acroreiser/android_kernel_lenovo_a6010/commit/935dfa33707c0707882a9adf7c9e4302eb33d60a
https://github.com/acroreiser/android_kernel_lenovo_a6010/commit/0e0121ade91d6c890953d1378ace8a99fa282316
https://github.com/acroreiser/android_kernel_lenovo_a6010/commit/bb831f82702389a103ef1d8d1efecb79c123d706
https://github.com/acroreiser/android_kernel_lenovo_a6010/commit/49de1da5ca50390fabc5cc090c9d3b91290d4ec7
https://github.com/acroreiser/android_kernel_lenovo_a6010/commit/9abd24f015d94f5e3b911c0fddb836bc75f23b82

**Device tree**
https://github.com/acroreiser/android_device_lenovo_a6010/commit/aeda34d04943f3c07712c079317231d0a99776da

**How to check is this feature works**
Logcat:

```
10-29 13:08:22.723  1913  2004 D ActivityManager: freezing 14433 com.google.android.apps.wellbeing

10-29 13:29:29.331  1913  6521 D ActivityManager: sync unfroze 14433 com.google.android.apps.wellbeing

10-29 13:30:13.931  1913  1935 I ActivityManager: com.android.vending is exempt from freezer
```


You can also see a new option in Developer options:

![IMG_20231029_143055_388](https://github.com/LineageOS-UL/android_frameworks_base/assets/10716792/9ff09d20-5160-4d9c-9ca3-9bb54391d363)


